### PR TITLE
Remove name duplication for matchers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,5 @@ end
 Gem::PackageTask.new(spec).define
 
 Rake::TestTask.new do |t|
-  t.ruby_opts = %w{-rminitest/pride}
   t.pattern = 'test/**/*.rb'
 end

--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -4,10 +4,10 @@ module Ramcrest
   module Aint
   module_function
     def aint(matcher)
-      AintMatcher.new(Ramcrest::EqualTo.to_matcher(matcher))
+      Matcher.new(Ramcrest::EqualTo.to_matcher(matcher))
     end
 
-    class AintMatcher
+    class Matcher
       include Ramcrest::Match
 
       def initialize(matcher)

--- a/lib/ramcrest/anything.rb
+++ b/lib/ramcrest/anything.rb
@@ -5,10 +5,10 @@ module Ramcrest
     module_function
 
     def anything
-      AnythingMatcher.new
+      Matcher.new
     end
 
-    class AnythingMatcher
+    class Matcher
       def matches?(actual)
         success
       end

--- a/lib/ramcrest/equal_to.rb
+++ b/lib/ramcrest/equal_to.rb
@@ -10,10 +10,10 @@ module Ramcrest
   module_function
 
     def equal_to(expected)
-      EqualToMatcher.new(expected)
+      Matcher.new(expected)
     end
 
-    class EqualToMatcher
+    class Matcher
       include Ramcrest::Match
 
       def initialize(expected)

--- a/lib/ramcrest/has_attribute.rb
+++ b/lib/ramcrest/has_attribute.rb
@@ -6,10 +6,10 @@ module Ramcrest
     module_function
 
     def has_attribute(attribute_name, value_matcher = Ramcrest::Anything.anything())
-      HasAttribute.new(attribute_name, value_matcher)
+      Matcher.new(attribute_name, value_matcher)
     end
 
-    class HasAttribute
+    class Matcher
       def initialize(attribute_name, value_matcher)
         @attribute_name = attribute_name
         @value_matcher = value_matcher
@@ -23,7 +23,7 @@ module Ramcrest
           else
             return mismatch("object <#{actual}> attribute '#{@attribute_name}' #{match.description}")
           end
-        else 
+        else
           return mismatch("object <#{actual}> was missing attribute '#{@attribute_name}'")
         end
       end

--- a/lib/ramcrest/includes_exactly.rb
+++ b/lib/ramcrest/includes_exactly.rb
@@ -6,10 +6,10 @@ module Ramcrest
 
     def includes_exactly(*expected)
       expected_matchers = expected.collect(&Ramcrest::EqualTo.method(:to_matcher))
-      IncludesExactlyMatcher.new(expected_matchers)
+      Matcher.new(expected_matchers)
     end
 
-    class IncludesExactlyMatcher < Ramcrest::Enumerable::BaseEnumerableMatcher
+    class Matcher < Ramcrest::Enumerable::BaseEnumerableMatcher
       def initialize(expected)
         super("including exactly", expected)
       end

--- a/lib/ramcrest/includes_in_any_order_exactly.rb
+++ b/lib/ramcrest/includes_in_any_order_exactly.rb
@@ -6,10 +6,10 @@ module Ramcrest
 
     def includes_in_any_order_exactly(*expected)
       expected_matchers = expected.collect(&Ramcrest::EqualTo.method(:to_matcher))
-      IncludesInAnyOrderExactlyMatcher.new(expected_matchers)
+      Matcher.new(expected_matchers)
     end
 
-    class IncludesInAnyOrderExactlyMatcher < Ramcrest::Enumerable::BaseEnumerableMatcher
+    class Matcher < Ramcrest::Enumerable::BaseEnumerableMatcher
       def initialize(expected)
         super("including in any order exactly", expected)
       end

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -5,10 +5,10 @@ module Ramcrest
   module_function
 
     def is(expected)
-      IsMatcher.new(Ramcrest::EqualTo.to_matcher(expected))
+      Matcher.new(Ramcrest::EqualTo.to_matcher(expected))
     end
 
-    class IsMatcher
+    class Matcher
       include Ramcrest::Match
 
       def initialize(expected)

--- a/lib/ramcrest/match.rb
+++ b/lib/ramcrest/match.rb
@@ -3,17 +3,17 @@ module Ramcrest
     module_function
 
     def success
-      MatchResult.new(true, nil)
+      MatchResult.new(true)
     end
 
-    def mismatch(description) 
+    def mismatch(description)
       MatchResult.new(false, description)
     end
 
     class MatchResult
       attr_reader :description
 
-      def initialize(matched, description)
+      def initialize(matched, description = nil)
         @matched = matched
         @description = description
       end

--- a/lib/ramcrest/such_that.rb
+++ b/lib/ramcrest/such_that.rb
@@ -5,10 +5,10 @@ module Ramcrest
   module_function
 
     def such_that(description = "<anonymous>", &matcher_block)
-      matcher = SuchThatMatcher.new(description, matcher_block)
+      matcher = Matcher.new(description, matcher_block)
     end
 
-    class SuchThatMatcher
+    class Matcher
       include Ramcrest::Match
 
       def initialize(description, matcher_block)


### PR DESCRIPTION
The enclosing module constitutes a reasonable namespace for the type of matcher. The implementation class inside of the module doesn't need to have the duplication. This sets a nice pattern for having something like

``` ruby
module TypeOfMatcher
   class Matcher
    #...
   end
end
```
