### PR TITLE
Eliminate matcher code duplication

### DIFF
--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module Aint
@@ -8,7 +8,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(expected)
         @expected = expected

--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -15,7 +15,7 @@ module Ramcrest
       end
 
       def do_match(expected, actual)
-        expected.matches?(actual).negate!
+        super.negate!
       end
 
       def mismatch_message(actual, match)

--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -14,17 +14,25 @@ module Ramcrest
         @expected = expected
       end
 
-      def matches?(actual)
-        match = @expected.matches?(actual)
-        if match.matched?
-          mismatch("<#{actual}>")
-        else
-          success
-        end
+      def do_match(actual)
+        @expected.matches?(actual).negate!
+      end
+
+      def mismatch_message(actual, match)
+        "<#{actual}>"
       end
 
       def description
         "not #{@expected.description}"
+      end
+
+      def matches?(actual)
+        match = do_match(actual)
+        if match.matched?
+          success
+        else
+          mismatch(mismatch_message(actual, match))
+        end
       end
     end
   end

--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -25,15 +25,6 @@ module Ramcrest
       def description
         "not #{@expected.description}"
       end
-
-      def matches?(actual)
-        match = do_match(actual)
-        if match.matched?
-          success
-        else
-          mismatch(mismatch_message(actual, match))
-        end
-      end
     end
   end
 end

--- a/lib/ramcrest/aint.rb
+++ b/lib/ramcrest/aint.rb
@@ -14,8 +14,8 @@ module Ramcrest
         @expected = expected
       end
 
-      def do_match(actual)
-        @expected.matches?(actual).negate!
+      def do_match(expected, actual)
+        expected.matches?(actual).negate!
       end
 
       def mismatch_message(actual, match)

--- a/lib/ramcrest/anything.rb
+++ b/lib/ramcrest/anything.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module Anything
@@ -9,7 +9,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def matches?(actual)
         success

--- a/lib/ramcrest/anything.rb
+++ b/lib/ramcrest/anything.rb
@@ -9,6 +9,8 @@ module Ramcrest
     end
 
     class Matcher
+      include Ramcrest::Match
+
       def matches?(actual)
         success
       end
@@ -16,8 +18,6 @@ module Ramcrest
       def description
         "anything"
       end
-
-      include Ramcrest::Match
     end
   end
 end

--- a/lib/ramcrest/base_enumerable_matcher.rb
+++ b/lib/ramcrest/base_enumerable_matcher.rb
@@ -1,9 +1,9 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module Enumerable
     class BaseEnumerableMatcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(match_type_description, expected, size_matcher)
         @match_type_description = match_type_description

--- a/lib/ramcrest/comparable.rb
+++ b/lib/ramcrest/comparable.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module Comparable
@@ -21,7 +21,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(name, operator, expected)
         @name = name

--- a/lib/ramcrest/equal_to.rb
+++ b/lib/ramcrest/equal_to.rb
@@ -20,12 +20,12 @@ module Ramcrest
         @expected = expected
       end
 
-      def matches?(actual)
-        if @expected == actual
-          success
-        else
-          mismatch("#{actual}")
-        end
+      def do_match(expected, actual)
+        MatchResult.new(expected == actual)
+      end
+
+      def mismatch_message(actual, match)
+        "#{actual}"
       end
 
       def description

--- a/lib/ramcrest/equal_to.rb
+++ b/lib/ramcrest/equal_to.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module EqualTo
@@ -14,7 +14,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(expected)
         @expected = expected

--- a/lib/ramcrest/has_attribute.rb
+++ b/lib/ramcrest/has_attribute.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 require 'ramcrest/anything'
 
 module Ramcrest
@@ -10,7 +10,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(attribute_name, value_matcher)
         @attribute_name = attribute_name

--- a/lib/ramcrest/has_attribute.rb
+++ b/lib/ramcrest/has_attribute.rb
@@ -10,6 +10,8 @@ module Ramcrest
     end
 
     class Matcher
+      include Ramcrest::Match
+
       def initialize(attribute_name, value_matcher)
         @attribute_name = attribute_name
         @value_matcher = value_matcher
@@ -31,8 +33,6 @@ module Ramcrest
       def description
         "an object with an attribute named '#{@attribute_name}' and value #{@value_matcher.description}"
       end
-
-      include Ramcrest::Match
     end
   end
 end

--- a/lib/ramcrest/has_size.rb
+++ b/lib/ramcrest/has_size.rb
@@ -16,7 +16,7 @@ module Ramcrest
       end
 
       def do_match(expected, actual)
-        expected.matches?(actual.size)
+        super expected, actual.size
       end
 
       def mismatch_message(actual, match)

--- a/lib/ramcrest/has_size.rb
+++ b/lib/ramcrest/has_size.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 require 'ramcrest/is'
 
 module Ramcrest
@@ -9,7 +9,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(expected)
         @expected = expected

--- a/lib/ramcrest/has_size.rb
+++ b/lib/ramcrest/has_size.rb
@@ -15,17 +15,25 @@ module Ramcrest
         @expected = expected
       end
 
-      def matches?(actual)
+      def do_match(actual)
         match = @expected.matches?(actual.size)
-        if match.matched?
-          success
-        else
-          mismatch("size #{match.description}")
-        end
+      end
+
+      def mismatch_message(actual, match)
+        "size #{match.description}"
       end
 
       def description
         "an enumerable of size #{@expected.description}"
+      end
+
+      def matches?(actual)
+        match = do_match(actual)
+        if match.matched?
+          success
+        else
+          mismatch(mismatch_message(actual, match))
+        end
       end
     end
   end

--- a/lib/ramcrest/has_size.rb
+++ b/lib/ramcrest/has_size.rb
@@ -26,15 +26,6 @@ module Ramcrest
       def description
         "an enumerable of size #{@expected.description}"
       end
-
-      def matches?(actual)
-        match = do_match(actual)
-        if match.matched?
-          success
-        else
-          mismatch(mismatch_message(actual, match))
-        end
-      end
     end
   end
 end

--- a/lib/ramcrest/has_size.rb
+++ b/lib/ramcrest/has_size.rb
@@ -15,8 +15,8 @@ module Ramcrest
         @expected = expected
       end
 
-      def do_match(actual)
-        match = @expected.matches?(actual.size)
+      def do_match(expected, actual)
+        expected.matches?(actual.size)
       end
 
       def mismatch_message(actual, match)

--- a/lib/ramcrest/includes.rb
+++ b/lib/ramcrest/includes.rb
@@ -10,8 +10,6 @@ module Ramcrest
     end
 
     class Matcher < Ramcrest::Enumerable::BaseEnumerableMatcher
-      include Ramcrest::Match
-
       def initialize(expected)
         super("including",
               expected,

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -31,15 +31,6 @@ module Ramcrest
       def description
         "is <#{@expected.description}>"
       end
-
-      def matches?(actual)
-        match = do_match(actual)
-        if match.matched?
-          success
-        else
-          mismatch(mismatch_message(actual, match))
-        end
-      end
     end
   end
 end

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -20,8 +20,8 @@ module Ramcrest
         @expected = expected
       end
 
-      def do_match(actual)
-        @expected.matches?(actual)
+      def do_match(expected, actual)
+        expected.matches?(actual)
       end
 
       def mismatch_message(actual, match)

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -20,10 +20,6 @@ module Ramcrest
         @expected = expected
       end
 
-      def do_match(expected, actual)
-        expected.matches?(actual)
-      end
-
       def mismatch_message(actual, match)
         "was <#{match.description}>"
       end

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -20,17 +20,25 @@ module Ramcrest
         @expected = expected
       end
 
-      def matches?(actual)
-        match = @expected.matches?(actual)
-        if match.matched?
-          success
-        else
-          mismatch("was <#{match.description}>")
-        end
+      def do_match(actual)
+        @expected.matches?(actual)
+      end
+
+      def mismatch_message(actual, match)
+        "was <#{match.description}>"
       end
 
       def description
         "is <#{@expected.description}>"
+      end
+
+      def matches?(actual)
+        match = do_match(actual)
+        if match.matched?
+          success
+        else
+          mismatch(mismatch_message(actual, match))
+        end
       end
     end
   end

--- a/lib/ramcrest/is.rb
+++ b/lib/ramcrest/is.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module Is
@@ -14,7 +14,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(expected)
         @expected = expected

--- a/lib/ramcrest/match.rb
+++ b/lib/ramcrest/match.rb
@@ -1,5 +1,7 @@
 module Ramcrest
   module Match
+
+
     module_function
 
     def success
@@ -16,10 +18,16 @@ module Ramcrest
       def initialize(matched, description = nil)
         @matched = matched
         @description = description
+        @negated = false
+      end
+
+      def negate!
+        @negated = true
+        self
       end
 
       def matched?
-        @matched
+        @negated ? !@matched : @matched
       end
     end
   end

--- a/lib/ramcrest/match.rb
+++ b/lib/ramcrest/match.rb
@@ -1,8 +1,14 @@
 module Ramcrest
   module Match
 
-
-    module_function
+    def matches?(actual)
+      match = do_match(actual)
+      if match.matched?
+        success
+      else
+        mismatch(mismatch_message(actual, match))
+      end
+    end
 
     def success
       MatchResult.new(true)

--- a/lib/ramcrest/match.rb
+++ b/lib/ramcrest/match.rb
@@ -2,7 +2,7 @@ module Ramcrest
   module Match
 
     def matches?(actual)
-      match = do_match(actual)
+      match = do_match(@expected, actual)
       if match.matched?
         success
       else

--- a/lib/ramcrest/match.rb
+++ b/lib/ramcrest/match.rb
@@ -1,6 +1,10 @@
 module Ramcrest
   module Match
 
+    def do_match(expected, actual)
+      expected.matches?(actual)
+    end
+
     def matches?(actual)
       match = do_match(@expected, actual)
       if match.matched?

--- a/lib/ramcrest/matcher.rb
+++ b/lib/ramcrest/matcher.rb
@@ -1,5 +1,5 @@
 module Ramcrest
-  module Match
+  module Matcher
 
     def do_match(expected, actual)
       expected.matches?(actual)

--- a/lib/ramcrest/matcher_matcher.rb
+++ b/lib/ramcrest/matcher_matcher.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module MatcherMatcher
@@ -16,7 +16,7 @@ module Ramcrest
     end
 
     class MatcherThatMatchesMatcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(value)
         @value = value
@@ -37,7 +37,7 @@ module Ramcrest
     end
 
     class MatcherDescribedAsMatcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(description)
         @description = description
@@ -57,7 +57,7 @@ module Ramcrest
     end
 
     class MatcherThatMismatchesMatcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(value, description)
         @value = value

--- a/lib/ramcrest/such_that.rb
+++ b/lib/ramcrest/such_that.rb
@@ -1,4 +1,4 @@
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
 module Ramcrest
   module SuchThat
@@ -9,7 +9,7 @@ module Ramcrest
     end
 
     class Matcher
-      include Ramcrest::Match
+      include Ramcrest::Matcher
 
       def initialize(description, matcher_block)
         singleton = class << self; self; end

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -1,8 +1,8 @@
 require 'minitest/autorun'
-require 'ramcrest/match'
+require 'ramcrest/matcher'
 
-describe Ramcrest::Match do
-  include Ramcrest::Match
+describe Ramcrest::Matcher do
+  include Ramcrest::Matcher
 
   it "a successful match is equivalent to true" do
     assert_equal true, success.matched?

--- a/test/match_test.rb
+++ b/test/match_test.rb
@@ -19,4 +19,11 @@ describe Ramcrest::Match do
   it "a successful match has no description" do
     assert_nil success.description
   end
+
+  describe "#negate!" do
+    it "inverts the result" do
+      assert_equal false, success.negate!.matched?
+      assert_equal true, mismatch("description").negate!.matched?
+    end
+  end
 end


### PR DESCRIPTION
Single-value matchers are incredibly similar in implementation. I've done a bit of refactoring to pull out the actual differences. This will allow easier creation of new single-value matchers.
There's similar logic with multiple-value matchers that could be extracted, I'm sure. This is a good first step, though.
